### PR TITLE
supporting new Xcode project structure (fixing compatibilityVersion error)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tadija/AEXML",
       "state" : {
-        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-        "version" : "4.6.1"
+        "revision" : "db806756c989760b35108146381535aec231092b",
+        "version" : "4.7.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/xcodeproj.git",
       "state" : {
-        "revision" : "313aaf1ad612135b7b0ccf731c86b5c07bf149b5",
-        "version" : "8.20.0"
+        "revision" : "621eca8d091cc110a99adc23bb0d6618a65b4544",
+        "version" : "9.13.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -6,14 +6,14 @@ import PackageDescription
 let package = Package(
     name: "spm-check-updates",
     platforms: [
-        .macOS(.v10_13)
+        .macOS(.v11)
     ],
     products: [
         .executable(name: "spm-check-updates", targets: ["spm-check-updates"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.1"),
-        .package(url: "https://github.com/tuist/xcodeproj.git", from: "8.20.0"),
+        .package(url: "https://github.com/tuist/xcodeproj.git", from: "9.0.0"),
         .package(url: "https://github.com/jkandzi/Progress.swift", from: "0.4.0"),
         .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.1")
     ],


### PR DESCRIPTION
On relatively new Xcode project files, I got this error when running spm-check-updates:

`Swift/ErrorType.swift:254: Fatal error: Error raised at top level: DecodingError.keyNotFound: Key 'compatibilityVersion' not found in keyed decoding container. Debug description: No value associated with key CodingKeys(stringValue: "compatibilityVersion", intValue: nil) ("compatibilityVersion").`

This is now fixed by upgrading the underlying Xcodeproj package.